### PR TITLE
remove unsupported comment

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Hunter – Hunts Performance Regressions
 ======================================
 
-_This is open source project was created by DataStax employees._
+_This open source project was created by DataStax employees._
 
 
 Hunter performs statistical analysis of performance test results stored

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Hunter – Hunts Performance Regressions
 ======================================
 
-_This is an unsupported open source project created by DataStax employees._
+_This is open source project was created by DataStax employees._
 
 
 Hunter performs statistical analysis of performance test results stored


### PR DESCRIPTION
It isn't great for community or potentially onboarding users for the top of the README to say is unsupported.  So, removed/changed that line.